### PR TITLE
Add merging interface

### DIFF
--- a/lively.graphics/color.js
+++ b/lively.graphics/color.js
@@ -384,6 +384,11 @@ export class Color {
     };
   }
 
+  __provideMergeStrategy__ (childA, childB) {
+    if (childA.equals(childB)) return childA;
+    return childA.equals(this) ? childB : childA;
+  }
+
   toJSExpr () {
     return `Color.${this.name || this.toString()}`;
   }

--- a/lively.graphics/geometry-2d.js
+++ b/lively.graphics/geometry-2d.js
@@ -253,6 +253,11 @@ export class Point {
   __serialize__ () {
     return { __expr__: this.toString(false), bindings: { 'lively.graphics/geometry-2d.js': ['pt'] } };
   }
+
+  __provideMergeStrategy__ (childA, childB) {
+    if (childA.equals(childB)) return childA;
+    return childA.equals(this) ? childB : childA;
+  }
 }
 
 export class Rectangle {

--- a/lively.merger/merger.js
+++ b/lively.merger/merger.js
@@ -59,6 +59,10 @@ export async function mergeMorphs (
 
   let parentMorph = await getLowestCommonAncestor(morphA, morphB);
 
+  if (typeof parentMorph.__provideMergeStrategy__ === 'function') {
+    return parentMorph.__provideMergeStrategy__(morphA, morphB);
+  }
+  
   let propertiesmorphA = propertiesFromMorph(morphA);
   let propertiesmorphB = propertiesFromMorph(morphB);
   let propertiesParentMorph = propertiesFromMorph(parentMorph);


### PR DESCRIPTION
A developer can now use the __provideMergeStrategy__ function on an object to set a custom merge strategy